### PR TITLE
Update dependency typescript to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Type check
+        run: npm run build
+
       - name: Run tests
         run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "ts-jest": "^29.4.4",
         "ts-node": "^10.0.0",
         "tslib": "^2.8.1",
-        "typescript": "^5.9.2"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -6366,9 +6366,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --noEmit",
     "bundle": "rollup -c",
     "format": "prettier --write .",
     "lint": "eslint .",
@@ -44,7 +44,7 @@
     "ts-jest": "^29.4.4",
     "ts-node": "^10.0.0",
     "tslib": "^2.8.1",
-    "typescript": "^5.9.2"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,11 @@
     "outDir": "./dist",
     "pretty": true,
     "resolveJsonModule": true,
+    "rootDir": ".",
     "strict": true,
     "strictNullChecks": true,
-    "target": "ES2022"
+    "target": "ES2022",
+    "types": ["node", "jest"]
   },
   "include": ["src", "__tests__", "rollup.config.ts"],
   "exclude": ["__fixtures__", "coverage", "dist", "node_modules"]


### PR DESCRIPTION
Upgrades TypeScript from 5.9 to 6.0. Two breaking changes in 6.0 required config updates:

- `@types/*` packages are no longer auto-included, so `fs`, `describe` and others resolved to `any`. Added `types: ["node", "jest"]`.
- Emitting now requires an explicit `rootDir` (TS5011). This surfaced through `ts-jest`, which failed the whole test suite.

`build` is changed to `tsc --noEmit`. It previously emitted into `dist/`, overwriting the rollup bundle that `action.yml` actually loads, and with `rootDir` set it would also have written test and fixture output there. rollup remains the real build.

Verified locally: format, lint, test, bundle and `tsc --noEmit` all pass.